### PR TITLE
Add simple task management UI with pie chart

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,44 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+.menu-bar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 0.5rem;
+  background-color: #333;
+  color: #fff;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+#appRoot {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.split {
+  display: flex;
+  flex: 1;
+  height: calc(100vh - 40px);
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.task-picker,
+.task-details {
+  flex: 1;
+  padding: 1rem;
+  overflow: auto;
 }
 
-.card {
-  padding: 2em;
+.task-picker {
+  border-right: 1px solid #444;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.read-the-docs {
-  color: #888;
+.task-details form > div {
+  margin-bottom: 1rem;
+}
+
+.pie text {
+  font-size: 12px;
+  fill: #fff;
+  pointer-events: none;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,161 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
+interface Task {
+  id: number
+  name: string
+  description: string
+  effort: number
+}
 
+function polarToCartesian(cx: number, cy: number, r: number, angle: number) {
+  return {
+    x: cx + r * Math.cos(angle),
+    y: cy + r * Math.sin(angle),
+  }
+}
+
+function describeArc(
+  cx: number,
+  cy: number,
+  r: number,
+  startAngle: number,
+  endAngle: number,
+) {
+  const start = polarToCartesian(cx, cy, r, startAngle)
+  const end = polarToCartesian(cx, cy, r, endAngle)
+  const largeArcFlag = endAngle - startAngle <= Math.PI ? 0 : 1
+  return `M ${cx} ${cy} L ${start.x} ${start.y} A ${r} ${r} 0 ${largeArcFlag} 1 ${end.x} ${end.y} Z`
+}
+
+function PieChart({
+  tasks,
+  selectedId,
+  onSelect,
+}: {
+  tasks: Task[]
+  selectedId: number | null
+  onSelect: (id: number) => void
+}) {
+  if (tasks.length === 0) {
+    return <p>No tasks yet</p>
+  }
+
+  const r = 100
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <svg
+      className="pie"
+      viewBox="-110 -110 220 220"
+      width={220}
+      height={220}
+    >
+      {tasks.map((task, i) => {
+        const start = (i / tasks.length) * Math.PI * 2
+        const end = ((i + 1) / tasks.length) * Math.PI * 2
+        const mid = (start + end) / 2
+        const path = describeArc(0, 0, r, start, end)
+        const color = `hsl(${(i * 70) % 360},70%,50%)`
+        const textPos = polarToCartesian(0, 0, r * 0.6, mid)
+        return (
+          <g key={task.id} onClick={() => onSelect(task.id)}>
+            <path
+              d={path}
+              fill={color}
+              stroke="#000"
+              strokeWidth={selectedId === task.id ? 3 : 1}
+            />
+            <text x={textPos.x} y={textPos.y} textAnchor="middle">
+              {task.name}
+            </text>
+          </g>
+        )
+      })}
+    </svg>
   )
 }
 
-export default App
+export default function App() {
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+
+  const addTask = () => {
+    const newTask: Task = {
+      id: Date.now(),
+      name: `New Task ${tasks.length + 1}`,
+      description: '',
+      effort: 100,
+    }
+    setTasks([...tasks, newTask])
+    setSelectedId(newTask.id)
+  }
+
+  const updateTask = (updated: Task) => {
+    setTasks(tasks.map((t) => (t.id === updated.id ? updated : t)))
+  }
+
+  const deleteTask = (id: number) => {
+    setTasks(tasks.filter((t) => t.id !== id))
+    if (selectedId === id) {
+      setSelectedId(null)
+    }
+  }
+
+  const selected = tasks.find((t) => t.id === selectedId) || null
+
+  return (
+    <div id="appRoot">
+      <div className="menu-bar">
+        <button onClick={addTask}>+</button>
+      </div>
+      <div className="split">
+        <div className="task-picker">
+          <PieChart tasks={tasks} selectedId={selectedId} onSelect={setSelectedId} />
+        </div>
+        <div className="task-details">
+          {selected ? (
+            <form>
+              <div>
+                <label>
+                  Name
+                  <input
+                    type="text"
+                    value={selected.name}
+                    onChange={(e) => updateTask({ ...selected, name: e.target.value })}
+                  />
+                </label>
+              </div>
+              <div>
+                <label>
+                  Description
+                  <br />
+                  <textarea
+                    value={selected.description}
+                    onChange={(e) => updateTask({ ...selected, description: e.target.value })}
+                  />
+                </label>
+              </div>
+              <div>
+                <label>
+                  Effort
+                  <input
+                    type="number"
+                    min={0}
+                    value={selected.effort}
+                    onChange={(e) =>
+                      updateTask({ ...selected, effort: Number(e.target.value) })
+                    }
+                  />
+                </label>
+              </div>
+              <button type="button" onClick={() => deleteTask(selected.id)}>
+                Delete Task
+              </button>
+            </form>
+          ) : (
+            <p>No task selected</p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- build UI with a menu bar, split view, and pie chart task picker
- update styles for menu, split layout, pie labels, and details form
- remove centered body styling
- move appRoot layout styles into CSS

## Testing
- `npm run lint`
- `npm run build`
- `npm run deploy`


------
https://chatgpt.com/codex/tasks/task_e_685618ad0f04833185bec95ed5f85444