### PR TITLE
Display build version in menu bar

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -14,11 +14,14 @@ Run `npm run deploy` to build and publish.
 Run `npm run build` to build the app.
 
 ### Publish
-1. Increment the patch version in the comment at the top of `index.html`.
+1. Increment the patch version in `index.html` by updating both the build
+   comment and the `meta[name="build-version"]` tag.
 2. Run `../publish` to publish the app to the live [GitHub Page](https://codefractal.github.io/task-rings).
    This is a binary that is maintained separately and lives outside of source control. Do not modify.
    It essentially just copies the `dist` folder to the `gh-pages` branch which is watched by GitHub Pages.
-   You'll need to wait 40 to 60 seconds for the changes to go live. You can verify your changes are live via the incremented version number you apply in the previous step.
+   You'll need to wait 40 to 60 seconds for the changes to go live. You can
+   verify your changes are live by checking the version number displayed in the
+   menu bar.
 
 ## Keeping Docs Up to Date
 If you make changes that affect setup or deployment, please update this file and the README so future developers stay informed.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ A visually expressive, nested task manager built around an interactive, animated
 ## Development
 A React web app built with Vite and TypeScript. The default styling uses a dark theme and the project is configured for deployment to GitHub Pages. The latest development build is available at <https://codefractal.github.io/task-rings/>.
 
+The current build version is displayed in the app's top menu bar.
+
 For development setup, see [DEVELOPING.md](DEVELOPING.md).

--- a/index.html
+++ b/index.html
@@ -1,10 +1,11 @@
-<!-- build version 0.0.5 -->
+<!-- build version 0.0.7 -->
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="build-version" content="0.0.7" />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,15 @@
 .menu-bar {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   padding: 0.5rem;
   background-color: #333;
   color: #fff;
+}
+
+.version {
+  font-weight: bold;
+  font-size: 1.2rem;
 }
 
 #appRoot {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,10 @@ import {
   calculateRotation,
 } from './utils/pie'
 
+const VERSION =
+  document.querySelector<HTMLMetaElement>('meta[name="build-version"]')?.content ||
+  '0.0.0'
+
 interface Task {
   id: number
   name: string
@@ -125,6 +129,7 @@ export default function App() {
   return (
     <div id="appRoot">
       <div className="menu-bar">
+        <span className="version">v{VERSION}</span>
         <button onClick={addTask}>+</button>
       </div>
       <div className="split">


### PR DESCRIPTION
## Summary
- add build version meta tag and display version in UI
- style and position version in the menu bar
- document version update steps
- bump build version to 0.0.7

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685636dcd5d483319a32018dfdf7fc0d