### PR TITLE
Implement modal for pending edits

### DIFF
--- a/DEPLOYMENT_TROUBLESHOOTING.md
+++ b/DEPLOYMENT_TROUBLESHOOTING.md
@@ -1,0 +1,14 @@
+# Deployment Troubleshooting
+
+If `npm run build` fails with errors like "Cannot find module 'react'" or missing
+`JSX` intrinsic elements, run `npm install` first. This installs all required
+packages so the TypeScript compiler can resolve module declarations.
+
+Steps:
+1. `npm install`
+2. `npm run build`
+3. `npm test` (optional but recommended)
+4. `../publish` to deploy
+
+Ensure you have network access to install packages. If the deploy fails, verify
+you can push to the `gh-pages` branch.

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!-- build version 0.0.3 -->
+<!-- build version 0.0.5 -->
 <!doctype html>
 <html lang="en">
   <head>

--- a/src/App.css
+++ b/src/App.css
@@ -37,6 +37,33 @@
   margin-bottom: 1rem;
 }
 
+.task-details label {
+  display: block;
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+.editable-display {
+  display: block;
+  width: 100%;
+  min-height: 1.5em;
+  padding: 0.25rem;
+  border: 1px solid #666;
+  border-radius: 4px;
+  cursor: text;
+}
+
+.editable-display:focus {
+  outline: 2px solid #888;
+}
+
+.editable-edit > input,
+.editable-edit > textarea {
+  width: 100%;
+  margin-bottom: 0.25rem;
+}
+
+
 .pie text {
   font-size: 12px;
   fill: #fff;

--- a/src/EditableField.tsx
+++ b/src/EditableField.tsx
@@ -1,0 +1,145 @@
+import {
+  forwardRef,
+  useEffect,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
+
+export interface EditableFieldProps {
+  value: string | number
+  onSave: (value: string | number) => void
+  render?: (value: string | number) => React.ReactNode
+  inputType?: string
+  multiline?: boolean
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>
+  textareaProps?: React.TextareaHTMLAttributes<HTMLTextAreaElement>
+  onDirtyChange?: (dirty: boolean) => void
+}
+
+export interface EditableFieldHandle {
+  save: () => void
+  revert: () => void
+  editing: boolean
+  dirty: boolean
+}
+
+const EditableField = forwardRef<EditableFieldHandle, EditableFieldProps>(
+  function EditableField(
+    {
+      value,
+      onSave,
+      render,
+      inputType = 'text',
+      multiline = false,
+      inputProps = {},
+      textareaProps = {},
+      onDirtyChange,
+    }: EditableFieldProps,
+    ref,
+  ) {
+  const [editing, setEditing] = useState(false)
+  const [pending, setPending] = useState<string | number>(value)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    setPending(value)
+    setEditing(false)
+  }, [value])
+
+  useEffect(() => {
+    if (editing) {
+      const el = multiline ? textareaRef.current : inputRef.current
+      el?.focus()
+    }
+  }, [editing, multiline])
+
+  const dirty = editing && pending !== value
+
+  useEffect(() => {
+    onDirtyChange?.(dirty)
+  }, [dirty, onDirtyChange])
+
+  const save = useCallback(() => {
+    onSave(pending)
+    setEditing(false)
+    onDirtyChange?.(false)
+  }, [onSave, pending, onDirtyChange])
+
+  const revert = useCallback(() => {
+    setPending(value)
+    setEditing(false)
+    onDirtyChange?.(false)
+  }, [value, onDirtyChange])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      save,
+      revert,
+      editing,
+      dirty,
+    }),
+    [save, revert, editing, dirty],
+  )
+
+  if (!editing) {
+    return (
+      <span
+        tabIndex={0}
+        className="editable-display"
+        onClick={() => setEditing(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            setEditing(true)
+          }
+        }}
+      >
+        {render ? render(value) : value === '' ? '\u00A0' : String(value)}
+      </span>
+    )
+  }
+
+  const commonProps = {
+    value: pending,
+    onChange: (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => setPending(e.target.value),
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (!multiline && e.key === 'Enter') {
+        e.preventDefault()
+        save()
+      }
+    },
+  }
+
+  return (
+    <span className="editable-edit">
+      {multiline ? (
+        <textarea
+          {...commonProps}
+          {...textareaProps}
+          ref={textareaRef}
+        />
+      ) : (
+        <input
+          type={inputType}
+          {...commonProps}
+          {...inputProps}
+          ref={inputRef}
+        />
+      )}
+      <button type="button" onClick={save}>
+        Save
+      </button>
+      <button type="button" onClick={revert}>
+        Revert
+      </button>
+    </span>
+  )
+})
+
+export default EditableField

--- a/src/Modal.css
+++ b/src/Modal.css
@@ -1,0 +1,28 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: #333;
+  color: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  min-width: 250px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+}
+
+.modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import type { ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import './Modal.css'
+
+export default function Modal({
+  children,
+  onClose,
+}: {
+  children: ReactNode
+  onClose: () => void
+}) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  return createPortal(
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>,
+    document.body,
+  )
+}


### PR DESCRIPTION
## Summary
- style editable fields and labels for better clarity
- handle unsaved edits with a modal when switching tasks
- expose editing controls via ref on `EditableField`
- support programmatic save and revert, track dirty state
- bump build version to 0.0.5
- use shared `Modal` component for unsaved-edit prompts
- restore troubleshooting notes

## Testing
- `npm test`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `npm run deploy`


------
https://chatgpt.com/codex/tasks/task_e_68562aee8fdc8331bead010f8757dc03