### PR TITLE
Implement modal for pending edits

### DIFF
--- a/DEPLOYMENT_TROUBLESHOOTING.md
+++ b/DEPLOYMENT_TROUBLESHOOTING.md
@@ -1,0 +1,14 @@
+# Deployment Troubleshooting
+
+If `npm run build` fails with errors like "Cannot find module 'react'" or missing
+`JSX` intrinsic elements, run `npm install` first. This installs all required
+packages so the TypeScript compiler can resolve module declarations.
+
+Steps:
+1. `npm install`
+2. `npm run build`
+3. `npm test` (optional but recommended)
+4. `../publish` to deploy
+
+Ensure you have network access to install packages. If the deploy fails, verify
+you can push to the `gh-pages` branch.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -14,11 +14,14 @@ Run `npm run deploy` to build and publish.
 Run `npm run build` to build the app.
 
 ### Publish
-1. Increment the patch version in the comment at the top of `index.html`.
+1. Increment the patch version in `index.html` by updating both the build
+   comment and the `meta[name="build-version"]` tag.
 2. Run `../publish` to publish the app to the live [GitHub Page](https://codefractal.github.io/task-rings).
    This is a binary that is maintained separately and lives outside of source control. Do not modify.
    It essentially just copies the `dist` folder to the `gh-pages` branch which is watched by GitHub Pages.
-   You'll need to wait 40 to 60 seconds for the changes to go live. You can verify your changes are live via the incremented version number you apply in the previous step.
+   You'll need to wait 40 to 60 seconds for the changes to go live. You can
+   verify your changes are live by checking the version number displayed in the
+   menu bar.
 
 ## Keeping Docs Up to Date
 If you make changes that affect setup or deployment, please update this file and the README so future developers stay informed.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ A visually expressive, nested task manager built around an interactive, animated
 ## Development
 A React web app built with Vite and TypeScript. The default styling uses a dark theme and the project is configured for deployment to GitHub Pages. The latest development build is available at <https://codefractal.github.io/task-rings/>.
 
+The current build version is displayed in the app's top menu bar.
+
 For development setup, see [DEVELOPING.md](DEVELOPING.md).

--- a/index.html
+++ b/index.html
@@ -1,10 +1,11 @@
-<!-- build version 0.0.3 -->
+<!-- build version 0.0.8 -->
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="build-version" content="0.0.8" />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,15 @@
 .menu-bar {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   padding: 0.5rem;
   background-color: #333;
   color: #fff;
+}
+
+.version {
+  font-weight: bold;
+  font-size: 1.2rem;
 }
 
 #appRoot {
@@ -36,6 +41,33 @@
 .task-details form > div {
   margin-bottom: 1rem;
 }
+
+.task-details label {
+  display: block;
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+}
+
+.editable-display {
+  display: block;
+  width: 100%;
+  min-height: 1.5em;
+  padding: 0.25rem;
+  border: 1px solid #666;
+  border-radius: 4px;
+  cursor: text;
+}
+
+.editable-display:focus {
+  outline: 2px solid #888;
+}
+
+.editable-edit > input,
+.editable-edit > textarea {
+  width: 100%;
+  margin-bottom: 0.25rem;
+}
+
 
 .pie text {
   font-size: 12px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import EditableField, { type EditableFieldHandle } from './EditableField'
 import './App.css'
+import Modal from './Modal'
 import {
   polarToCartesian,
   describeArc,
@@ -7,11 +9,16 @@ import {
   calculateRotation,
 } from './utils/pie'
 
+const VERSION =
+  document.querySelector<HTMLMetaElement>('meta[name="build-version"]')?.content ||
+  '0.0.0'
+
 interface Task {
   id: number
   name: string
   description: string
   effort: number
+  completed: boolean
 }
 
 function useIsMobile() {
@@ -29,7 +36,6 @@ function useIsMobile() {
 
   return isMobile
 }
-
 
 function PieChart({
   tasks,
@@ -64,7 +70,7 @@ function PieChart({
         {tasks.map((task, i) => {
           const { start, end, mid } = angles[i]
           const path = describeArc(0, 0, r, start, end)
-          const color = `hsl(${(i * 70) % 360},70%,50%)`
+          const color = task.completed ? '#006400' : '#555'
           const textPos = polarToCartesian(0, 0, r * 0.6, mid)
           return (
             <g key={task.id} onClick={() => onSelect(task.id)}>
@@ -93,6 +99,18 @@ function PieChart({
 export default function App() {
   const [tasks, setTasks] = useState<Task[]>([])
   const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [pendingName, setPendingName] = useState(false)
+  const [pendingDesc, setPendingDesc] = useState(false)
+  const [pendingEffort, setPendingEffort] = useState(false)
+  const [targetId, setTargetId] = useState<number | null>(null)
+  const [showUnsavedModal, setShowUnsavedModal] = useState(false)
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null)
+
+  const nameRef = useRef<EditableFieldHandle>(null)
+  const descRef = useRef<EditableFieldHandle>(null)
+  const effortRef = useRef<EditableFieldHandle>(null)
+
+  const hasPending = pendingName || pendingDesc || pendingEffort
 
   const addTask = () => {
     const newTask: Task = {
@@ -100,6 +118,7 @@ export default function App() {
       name: `New Task ${tasks.length + 1}`,
       description: '',
       effort: 100,
+      completed: false,
     }
     setTasks([...tasks, newTask])
     setSelectedId(newTask.id)
@@ -116,16 +135,49 @@ export default function App() {
     }
   }
 
+  const handleSelect = (id: number) => {
+    if (id === selectedId) return
+    if (hasPending) {
+      setTargetId(id)
+      setShowUnsavedModal(true)
+    } else {
+      setSelectedId(id)
+    }
+  }
+
+  const saveAll = () => {
+    nameRef.current?.save()
+    descRef.current?.save()
+    effortRef.current?.save()
+    setShowUnsavedModal(false)
+    if (targetId !== null) {
+      setSelectedId(targetId)
+      setTargetId(null)
+    }
+  }
+
+  const discardAll = () => {
+    nameRef.current?.revert()
+    descRef.current?.revert()
+    effortRef.current?.revert()
+    setShowUnsavedModal(false)
+    if (targetId !== null) {
+      setSelectedId(targetId)
+      setTargetId(null)
+    }
+  }
+
   const selected = tasks.find((t) => t.id === selectedId) || null
 
   return (
     <div id="appRoot">
       <div className="menu-bar">
+        <span className="version">v{VERSION}</span>
         <button onClick={addTask}>+</button>
       </div>
       <div className="split">
         <div className="task-picker">
-          <PieChart tasks={tasks} selectedId={selectedId} onSelect={setSelectedId} />
+          <PieChart tasks={tasks} selectedId={selectedId} onSelect={handleSelect} />
         </div>
         <div className="task-details">
           {selected ? (
@@ -133,10 +185,11 @@ export default function App() {
               <div>
                 <label>
                   Name
-                  <input
-                    type="text"
+                  <EditableField
+                    ref={nameRef}
                     value={selected.name}
-                    onChange={(e) => updateTask({ ...selected, name: e.target.value })}
+                    onDirtyChange={setPendingName}
+                    onSave={(v) => updateTask({ ...selected, name: v as string })}
                   />
                 </label>
               </div>
@@ -144,26 +197,43 @@ export default function App() {
                 <label>
                   Description
                   <br />
-                  <textarea
+                  <EditableField
+                    ref={descRef}
+                    multiline
                     value={selected.description}
-                    onChange={(e) => updateTask({ ...selected, description: e.target.value })}
+                    onDirtyChange={setPendingDesc}
+                    onSave={(v) => updateTask({ ...selected, description: v as string })}
                   />
                 </label>
               </div>
               <div>
                 <label>
                   Effort
-                  <input
-                    type="number"
-                    min={0}
+                  <EditableField
+                    ref={effortRef}
+                    inputType="number"
+                    inputProps={{ min: 0 }}
                     value={selected.effort}
-                    onChange={(e) =>
-                      updateTask({ ...selected, effort: Number(e.target.value) })
+                    onDirtyChange={setPendingEffort}
+                    onSave={(v) =>
+                      updateTask({ ...selected, effort: Number(v) })
                     }
                   />
                 </label>
               </div>
-              <button type="button" onClick={() => deleteTask(selected.id)}>
+              <div>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={selected.completed}
+                    onChange={(e) =>
+                      updateTask({ ...selected, completed: e.target.checked })
+                    }
+                  />{' '}
+                  Completed
+                </label>
+              </div>
+              <button type="button" onClick={() => setConfirmDeleteId(selected.id)}>
                 Delete Task
               </button>
             </form>
@@ -172,6 +242,32 @@ export default function App() {
           )}
         </div>
       </div>
+      {showUnsavedModal && (
+        <Modal onClose={() => setShowUnsavedModal(false)}>
+          <p>You have unsaved changes.</p>
+          <div className="modal-buttons">
+            <button onClick={saveAll}>Save</button>
+            <button onClick={discardAll}>Discard</button>
+            <button onClick={() => setShowUnsavedModal(false)}>Cancel</button>
+          </div>
+        </Modal>
+      )}
+      {confirmDeleteId !== null && (
+        <Modal onClose={() => setConfirmDeleteId(null)}>
+          <p>Delete this task?</p>
+          <div className="modal-buttons">
+            <button
+              onClick={() => {
+                deleteTask(confirmDeleteId)
+                setConfirmDeleteId(null)
+              }}
+            >
+              Delete
+            </button>
+            <button onClick={() => setConfirmDeleteId(null)}>Cancel</button>
+          </div>
+        </Modal>
+      )}
     </div>
   )
 }

--- a/src/EditableField.tsx
+++ b/src/EditableField.tsx
@@ -1,0 +1,145 @@
+import {
+  forwardRef,
+  useEffect,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
+
+export interface EditableFieldProps {
+  value: string | number
+  onSave: (value: string | number) => void
+  render?: (value: string | number) => React.ReactNode
+  inputType?: string
+  multiline?: boolean
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>
+  textareaProps?: React.TextareaHTMLAttributes<HTMLTextAreaElement>
+  onDirtyChange?: (dirty: boolean) => void
+}
+
+export interface EditableFieldHandle {
+  save: () => void
+  revert: () => void
+  editing: boolean
+  dirty: boolean
+}
+
+const EditableField = forwardRef<EditableFieldHandle, EditableFieldProps>(
+  function EditableField(
+    {
+      value,
+      onSave,
+      render,
+      inputType = 'text',
+      multiline = false,
+      inputProps = {},
+      textareaProps = {},
+      onDirtyChange,
+    }: EditableFieldProps,
+    ref,
+  ) {
+  const [editing, setEditing] = useState(false)
+  const [pending, setPending] = useState<string | number>(value)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    setPending(value)
+    setEditing(false)
+  }, [value])
+
+  useEffect(() => {
+    if (editing) {
+      const el = multiline ? textareaRef.current : inputRef.current
+      el?.focus()
+    }
+  }, [editing, multiline])
+
+  const dirty = editing && pending !== value
+
+  useEffect(() => {
+    onDirtyChange?.(dirty)
+  }, [dirty, onDirtyChange])
+
+  const save = useCallback(() => {
+    onSave(pending)
+    setEditing(false)
+    onDirtyChange?.(false)
+  }, [onSave, pending, onDirtyChange])
+
+  const revert = useCallback(() => {
+    setPending(value)
+    setEditing(false)
+    onDirtyChange?.(false)
+  }, [value, onDirtyChange])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      save,
+      revert,
+      editing,
+      dirty,
+    }),
+    [save, revert, editing, dirty],
+  )
+
+  if (!editing) {
+    return (
+      <span
+        tabIndex={0}
+        className="editable-display"
+        onClick={() => setEditing(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            setEditing(true)
+          }
+        }}
+      >
+        {render ? render(value) : value === '' ? '\u00A0' : String(value)}
+      </span>
+    )
+  }
+
+  const commonProps = {
+    value: pending,
+    onChange: (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => setPending(e.target.value),
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (!multiline && e.key === 'Enter') {
+        e.preventDefault()
+        save()
+      }
+    },
+  }
+
+  return (
+    <span className="editable-edit">
+      {multiline ? (
+        <textarea
+          {...commonProps}
+          {...textareaProps}
+          ref={textareaRef}
+        />
+      ) : (
+        <input
+          type={inputType}
+          {...commonProps}
+          {...inputProps}
+          ref={inputRef}
+        />
+      )}
+      <button type="button" onClick={save}>
+        Save
+      </button>
+      <button type="button" onClick={revert}>
+        Revert
+      </button>
+    </span>
+  )
+})
+
+export default EditableField

--- a/src/Modal.css
+++ b/src/Modal.css
@@ -1,0 +1,28 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: #333;
+  color: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  min-width: 250px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+}
+
+.modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+import type { ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import './Modal.css'
+
+export default function Modal({
+  children,
+  onClose,
+}: {
+  children: ReactNode
+  onClose: () => void
+}) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  return createPortal(
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>,
+    document.body,
+  )
+}


### PR DESCRIPTION
## Summary
- style editable fields and labels for better clarity
- handle unsaved edits with a modal when switching tasks
- expose editing controls via ref on `EditableField`
- support programmatic save and revert, track dirty state
- bump build version to 0.0.8
- use shared `Modal` component for unsaved-edit prompts
- restore troubleshooting notes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find '@eslint/js')*
- `npx tsc --noEmit`
- `npm run build` *(fails: missing dependencies)*
- `npm run deploy` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68562aee8fdc8331bead010f8757dc03