### PR TITLE
Fix mobile zoom on input

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,11 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
+
+input,
+textarea {
+  font-size: 16px;
+}
 button:hover {
   border-color: #646cff;
 }


### PR DESCRIPTION
## Summary
- ensure input fields use a 16px font size so mobile browsers don't zoom when focusing them

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_685691b53e008331b77a630361c45dee