### PR TITLE
Merge subtask navigation branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ A React web app built with Vite and TypeScript. The default styling uses a dark 
 The current build version is displayed in the app's top menu bar.
 
 For development setup, see [DEVELOPING.md](DEVELOPING.md).
+
+## Usage
+- Click a slice to focus on that task's subtasks.
+- Use the center ring to navigate back to the parent task.
+- Use **Add Sibling Task** to create a task under the same parent as the current selection.

--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
-<!-- build version 0.0.12 -->
+<!-- build version 0.0.13 -->
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="build-version" content="0.0.12" />
+    <meta name="build-version" content="0.0.13" />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -75,6 +75,11 @@
   pointer-events: none;
 }
 
+.pie path.selected {
+  stroke: yellow;
+  stroke-width: 3;
+}
+
 @media (max-width: 600px) {
   .split {
     flex-direction: column;

--- a/src/utils/pie.test.ts
+++ b/src/utils/pie.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { polarToCartesian, calculateAngles, calculateRotation } from './pie'
+import {
+  polarToCartesian,
+  calculateAngles,
+  calculateRotation,
+  describeRingArc,
+} from './pie'
 
 describe('polarToCartesian', () => {
   it('converts polar coordinates to cartesian', () => {
@@ -37,5 +42,13 @@ describe('calculateRotation', () => {
   it('rotates for mobile', () => {
     const rot = calculateRotation(Math.PI / 4, true)
     expect(rot).toBeCloseTo(-Math.PI / 2 - Math.PI / 4)
+  })
+})
+
+describe('describeRingArc', () => {
+  it('creates an svg path for an annular sector', () => {
+    const path = describeRingArc(0, 0, 1, 2, 0, Math.PI)
+    expect(path.startsWith('M')).toBe(true)
+    expect(path.endsWith('Z')).toBe(true)
   })
 })

--- a/src/utils/pie.ts
+++ b/src/utils/pie.ts
@@ -28,6 +28,28 @@ export function describeArc(
   return `M ${cx} ${cy} L ${start.x} ${start.y} A ${r} ${r} 0 ${largeArcFlag} 1 ${end.x} ${end.y} Z`
 }
 
+export function describeRingArc(
+  cx: number,
+  cy: number,
+  rInner: number,
+  rOuter: number,
+  startAngle: number,
+  endAngle: number,
+): string {
+  const outerStart = polarToCartesian(cx, cy, rOuter, startAngle)
+  const outerEnd = polarToCartesian(cx, cy, rOuter, endAngle)
+  const innerEnd = polarToCartesian(cx, cy, rInner, endAngle)
+  const innerStart = polarToCartesian(cx, cy, rInner, startAngle)
+  const largeArcFlag = endAngle - startAngle <= Math.PI ? 0 : 1
+  return [
+    `M ${outerStart.x} ${outerStart.y}`,
+    `A ${rOuter} ${rOuter} 0 ${largeArcFlag} 1 ${outerEnd.x} ${outerEnd.y}`,
+    `L ${innerEnd.x} ${innerEnd.y}`,
+    `A ${rInner} ${rInner} 0 ${largeArcFlag} 0 ${innerStart.x} ${innerStart.y}`,
+    'Z',
+  ].join(' ')
+}
+
 export interface TaskLike {
   effort: number
 }


### PR DESCRIPTION
## Summary
- merge `codex/implement-subtask-navigation-in-task-view`
- highlight selected tasks in the pie chart
- add subtask navigation utilities
- document how to navigate tasks
- fix unsaved changes modal save logic
- add sibling task support and always show center circle
- show current task ring around parent so center circle stays clickable

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `../publish`


------
https://chatgpt.com/codex/tasks/task_e_6856b47cc6d08331a56960d4027d75d1