### PR TITLE
Add Google Drive persistence

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -10,6 +10,9 @@ Welcome! This guide helps new contributors get started and keep our documentatio
 Run `npm run deploy` to build and publish.
 *Note: this does not automatically increment the version number. See the **Publish** section for more details.*
 
+### Google Drive
+Saving is handled through Google Drive. The app loads the Google API and Identity scripts from Google's CDN (see `index.html`). During development you may be prompted to sign in when the app starts.
+
 ### Build
 Run `npm run build` to build the app.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # task-rings
-A visually expressive, nested task manager built around an interactive, animated pie chart UI. Navigate tasks like file directories, zoom into subtasks, and sync everything via Google Drive using a clean JSON format.
+A visually expressive, nested task manager built around an interactive, animated pie chart UI. Navigate tasks like file directories, zoom into subtasks, and sync everything via Google Drive using a clean JSON format. Saving occurs automatically whenever tasks change.
 
 ## Development
 A React web app built with Vite and TypeScript. The default styling uses a dark theme and the project is configured for deployment to GitHub Pages. The latest development build is available at <https://codefractal.github.io/task-rings/>.
@@ -12,3 +12,6 @@ For development setup, see [DEVELOPING.md](DEVELOPING.md).
 - Click a slice to focus on that task's subtasks.
 - Use the center ring to navigate back to the parent task.
 - Use **Add Sibling Task** to create a task under the same parent as the current selection.
+- The first time you load the app you will be prompted to sign in with Google Drive.
+- A file can be specified in the URL using `?s=g&l=<fileId>`.
+- If no file is specified, you can create a new one or choose an existing file after signing in.

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="build-version" content="0.0.13" />
     <title>Vite + React + TS</title>
+    <script src="https://apis.google.com/js/api.js"></script>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,22 @@
   color: #fff;
 }
 
+.spinner {
+  margin-left: 0.5rem;
+  border: 4px solid rgba(255, 255, 255, 0.2);
+  border-left-color: #fff;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .version {
   font-weight: bold;
   font-size: 1.2rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
+import { GoogleDriveService } from './storage/GoogleDriveService'
+import { QueryStringHandler } from './storage/QueryStringHandler'
 import EditableField, { type EditableFieldHandle } from './EditableField'
 import './App.css'
 import Modal from './Modal'
@@ -13,6 +15,9 @@ import {
 const VERSION =
   document.querySelector<HTMLMetaElement>('meta[name="build-version"]')?.content ||
   '0.0.0'
+
+const driveService = new GoogleDriveService()
+const queryHandler = new QueryStringHandler()
 
 interface Task {
   id: number
@@ -197,6 +202,9 @@ let nextId = 1
 
 export default function App() {
   const [tasks, setTasks] = useState<Task[]>([])
+  const [fileId, setFileId] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const loadedRef = useRef(false)
   const [path, setPath] = useState<number[]>([])
   const [pendingName, setPendingName] = useState(false)
   const [pendingDesc, setPendingDesc] = useState(false)
@@ -212,7 +220,63 @@ export default function App() {
   const descRef = useRef<EditableFieldHandle>(null)
   const effortRef = useRef<EditableFieldHandle>(null)
 
+  useEffect(() => {
+    async function init() {
+      if (!driveService.tryAutoSignIn()) {
+        const ok = await driveService.signIn()
+        if (!ok) return
+      }
+      const loc = queryHandler.getStorageLocation()
+      let id = loc?.id || null
+      if (!id) {
+        const createNew = confirm('Create a new task file? Click Cancel to open existing.')
+        if (createNew) {
+          const folder = await driveService.pickFolder()
+          if (folder === null) return
+          let name = prompt('Enter file name', 'tasks.tr.json') || 'tasks.tr.json'
+          if (!name.endsWith('.tr.json')) name += '.tr.json'
+          id = await driveService.saveAs(
+            name,
+            folder,
+            JSON.stringify({ version: '1', tasks: [] }, null, 2),
+            'application/json',
+          )
+        } else {
+          id = await driveService.pickFile('application/json')
+        }
+        if (!id) return
+        queryHandler.setStorageLocation({ source: 'g', id })
+      }
+      setFileId(id)
+      const content = await driveService.open(id)
+      if (content) {
+        try {
+          const data = JSON.parse(content) as { tasks: Task[] }
+          setTasks(data.tasks)
+        } catch {
+          // ignore
+        }
+      }
+      loadedRef.current = true
+    }
+    init()
+  }, [])
+
   const hasPending = pendingName || pendingDesc || pendingEffort
+
+  useEffect(() => {
+    if (!loadedRef.current || !fileId) return
+    const timer = setTimeout(async () => {
+      setSaving(true)
+      await driveService.save(
+        fileId,
+        JSON.stringify({ tasks }, null, 2),
+        'application/json',
+      )
+      setSaving(false)
+    }, 1000)
+    return () => clearTimeout(timer)
+  }, [tasks, fileId])
 
   const createTaskAtPath = (parent: number[]) => {
     const id = nextId++
@@ -316,6 +380,7 @@ export default function App() {
     <div id="appRoot">
       <div className="menu-bar">
         <span className="version">v{VERSION}</span>
+        {saving && <span className="spinner" aria-label="Saving" />}
         <button onClick={addTask}>+</button>
       </div>
       <div className="split">

--- a/src/storage/GoogleDriveService.ts
+++ b/src/storage/GoogleDriveService.ts
@@ -1,0 +1,328 @@
+declare const gapi: any;
+declare const google: any;
+
+export class GoogleDriveService {
+    private readonly CLIENT_ID = '834406545740-fpa6k2omak75t15u8ve4t7n0t3r1r0ig.apps.googleusercontent.com';
+    private readonly API_KEY = 'AIzaSyCMJf3NuTEBASgWaXTQhy6fiM9QY0GAitg';
+    private readonly DISCOVERY_DOCS = ["https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"];
+    private readonly SCOPES = 'https://www.googleapis.com/auth/drive';
+
+    private tokenClient: any = null;
+    private accessToken: AccessToken | null = null;
+
+    constructor() {
+        this.init();
+    }
+
+    /**
+     * Initializes the Google API client and token client.
+     */
+    private init(): void {
+        // Load the GAPI client.
+        gapi.load('client', () => {
+            gapi.client.init({
+                apiKey: this.API_KEY,
+                discoveryDocs: this.DISCOVERY_DOCS
+            }).then(() => {
+                console.log("GAPI client initialized.");
+            }).catch((error: any) => {
+                console.error("Error initializing GAPI client:", error);
+            });
+        });
+
+        // Initialize the token client using the Google Identity Services library.
+        // Note: Make sure the gsi/client script is loaded.
+        this.tokenClient = google.accounts.oauth2.initTokenClient({
+            client_id: this.CLIENT_ID,
+            scope: this.SCOPES,
+            callback: (response: any) => {
+                // Default callback if needed.
+                if (response.error) {
+                    console.error("Error during token acquisition:", response.error);
+                } 
+                else {
+                    this.accessToken = AccessToken.fromResponse(response);
+                    console.log("Access token acquired:", this.accessToken.token);
+                }
+            }
+        });
+    }
+
+    /**
+     * Attempts to automatically sign in the user using an existing token.
+     * Returns true if sign-in was successful, otherwise false.
+     */
+    public tryAutoSignIn(): boolean {
+        const existingToken = AccessToken.getExisting();
+        if (existingToken) {
+            this.accessToken = existingToken;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Prompts the user to sign in with their Google account.
+     * Returns a promise that resolves to true if sign-in was successful, otherwise false.
+     */
+    public signIn(): Promise<boolean> {
+        return new Promise((resolve, reject) => {
+            if (!this.tokenClient) {
+                return reject(new Error("Token client not initialized."));
+            }
+            // Temporarily override the callback for this sign-in attempt.
+            const originalCallback = this.tokenClient.callback;
+            this.tokenClient.callback = (response: IAccessTokenResponse) => {
+                if (response.error) {
+                    console.error("Sign-in error:", response.error);
+                    resolve(false);
+                }
+                else {
+                    this.accessToken = AccessToken.fromResponse(response);
+                    console.log("User signed in, token:", this.accessToken.token);
+                    resolve(true);
+                }
+                // Restore the original callback.
+                this.tokenClient.callback = originalCallback;
+            };
+            this.tokenClient.requestAccessToken();
+        });
+    }
+
+    /**
+     * Continuously prompts the user to sign in with their Google account until successful.
+     */
+    private async getAccessTokenValidFor(seconds: number): Promise<AccessToken> {
+        const currentToken = this.accessToken || AccessToken.getExisting();
+        if (currentToken && !currentToken.expiresWithin(seconds)) {
+            return currentToken;
+        }
+        while (true) {
+            await this.signIn();
+            if (this.accessToken?.expiresWithin(seconds) === false) {
+                return this.accessToken;
+            }
+        }
+    }
+
+    /**
+     * Prompts the user to select a folder.
+     * Returns a promise that resolves to the selected folder (an object with its ID)
+     * or null if the user dismisses the modal.
+     */
+    public pickFolder(): Promise<string | null> {
+        return new Promise((resolve) => {
+            // Load the Picker API.
+            gapi.load('picker', async () => {
+                const folderView = new google.picker.DocsView(google.picker.ViewId.FOLDERS)
+                    .setParent('root')
+                    .setMode(google.picker.DocsViewMode.LIST)
+                    .setSelectFolderEnabled(true);
+
+                const accessToken = await this.getAccessTokenValidFor(60);
+                const picker = new google.picker.PickerBuilder()
+                    .addView(folderView)
+                    .setOAuthToken(accessToken.token)
+                    .setDeveloperKey(this.API_KEY)
+                    .setCallback((data: any) => {
+                        if (data.action === google.picker.Action.PICKED) {
+                            const folderId = data.docs[0].id;
+                            resolve(folderId);
+                        }
+                        else if (data.action === google.picker.Action.CANCEL) {
+                            resolve(null);
+                        }
+                    })
+                    .build();
+
+                picker.setVisible(true);
+            });
+        });
+    }
+
+    /**
+     * Prompts the user to select a file.
+     * Returns a promise that resolves to the selected file (an object with its ID)
+     * or null if the user dismisses the modal.
+     */
+    public pickFile(mimeTypes?: string | string[]): Promise<string | null> {
+        const mimeTypeString = Array.isArray(mimeTypes) ?
+            mimeTypes.length > 0 ? mimeTypes.join(',') : undefined :
+            mimeTypes;
+
+        return new Promise<string | null>((resolve) => {
+            // Load the Picker API.
+            gapi.load('picker', async () => {
+                const fileView = new google.picker.DocsView(google.picker.ViewId.DOCS)
+                    .setIncludeFolders(true)
+                    .setParent('root')
+                    .setMode(google.picker.DocsViewMode.LIST);
+    
+                if (mimeTypeString) {
+                    fileView.setMimeTypes(mimeTypeString);
+                }
+    
+                const accessToken = await this.getAccessTokenValidFor(60);
+                const picker = new google.picker.PickerBuilder()
+                    .addView(fileView)
+                    .setOAuthToken(accessToken.token)
+                    .setDeveloperKey(this.API_KEY)
+                    .setCallback((data: any) => {
+                        if (data.action === google.picker.Action.PICKED) {
+                            const fileId = data.docs[0].id;
+                            resolve(fileId);
+                        }
+                        else if (data.action === google.picker.Action.CANCEL) {
+                            resolve(null);
+                        }
+                    })
+                    .build();
+    
+                picker.setVisible(true);
+            });
+        });
+    }
+
+    /**
+     * Saves the given content as a new file on Google Drive.
+     * @param fileName The name of the file to be created
+     * @param folderId The ID of the folder where the file should be created
+     * @param content The content to be saved in the file
+     * @returns The ID of the newly created file, or null if the file could not be created
+     */
+    public saveAs(fileName: string, folderId: string, content: string, mimeType?: string): Promise<string | null> {
+        return new Promise(async (resolve) => {
+            const file = new Blob([content], { type: mimeType });
+            let metadata: any = {
+                name: fileName,
+                mimeType: mimeType
+            };
+            if (folderId !== 'root') {
+                metadata.parents = [folderId];
+            }
+            const form = new FormData();
+            form.append('metadata', new Blob([JSON.stringify(metadata)], { type: 'application/json' }));
+            form.append('file', file);
+
+            const accessToken = await this.getAccessTokenValidFor(20);
+            fetch('https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id', {
+                method: 'POST',
+                headers: new Headers({ 'Authorization': 'Bearer ' + accessToken.token }),
+                body: form
+            })
+                .then(res => res.json())
+                .then(result => {
+                    resolve(result.id);
+                })
+                .catch(err => {
+                    console.error("Error creating file:", err);
+                    resolve(null);
+                });
+        });
+    }
+
+    /**
+     * Saves the given content to an existing file on Google Drive.
+     * @param fileId The ID of the file to be updated
+     * @param content The content to be saved in the file
+     */
+    public save(fileId: string, content: string, mimeType?: string): Promise<void> {
+        return new Promise(async (resolve) => {
+            const accessToken = await this.getAccessTokenValidFor(20);
+            fetch(`https://www.googleapis.com/upload/drive/v3/files/${fileId}?uploadType=media`, {
+                method: 'PATCH',
+                headers: new Headers({
+                    'Authorization': 'Bearer ' + accessToken.token,
+                    'Content-Type': mimeType || 'text/plain'
+                }),
+                body: content
+            })
+                .then(() => resolve())
+                .catch(err => {
+                    console.error("Error saving file:", err);
+                    resolve();
+                });
+        });
+    }
+
+    /**
+     * Retrieves the content of a file from Google Drive.
+     * @param fileId The ID of the file to retrieve
+     * @returns The content of the file, or null if the file could not be retrieved
+     */
+    public open(fileId: string): Promise<string | null> {
+        return new Promise(async (resolve) => {
+            const accessToken = await this.getAccessTokenValidFor(20);
+            fetch(`https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`, {
+                headers: new Headers({ 'Authorization': 'Bearer ' + accessToken.token })
+            })
+                .then(res => res.text())
+                .then(content => resolve(content))
+                .catch(err => {
+                    console.error("Error opening file:", err);
+                    resolve(null);
+                });
+        });
+    }
+}
+
+class AccessToken {
+    private static readonly TOKEN_KEY = 'googleAccessToken';
+    private static readonly EXPIRY_KEY = 'googleAccessTokenExpires';
+
+    public static getExisting(): AccessToken | null {
+        const token = localStorage.getItem(AccessToken.TOKEN_KEY);
+        if (!token) return null;
+
+        const expiry = localStorage.getItem(AccessToken.EXPIRY_KEY);
+        if (!expiry) return null;
+
+        try {
+            const expires = new Date(expiry);
+
+            // If the token expires in less than 1 minute, don't return it.
+            if (expires.getTime() - Date.now() <= 60_000) return null;
+
+            return new AccessToken(token, expires, false);
+        }
+        catch {
+            return null;
+        }
+    }
+
+    public static fromResponse(response: IAccessTokenResponse): AccessToken {
+        if (!response.access_token || !response.expires_in) {
+            throw new Error(`Invalid access token response: ${JSON.stringify(response)}`);
+        }
+
+        const token = response.access_token;
+        const expires = new Date(Date.now() + response.expires_in * 1000);
+        return new AccessToken(token, expires, true);
+    }
+
+    public readonly token: string;
+    public readonly expires: Date;
+
+    private constructor(token: string, expires: Date, autoSave: boolean) {
+        this.token = token;
+        this.expires = expires;
+        if (autoSave) {
+            localStorage.setItem(AccessToken.TOKEN_KEY, token);
+            localStorage.setItem(AccessToken.EXPIRY_KEY, expires.toISOString());
+        }
+    }
+
+    public expiresWithin(seconds: number): boolean {
+        return this.expires.getTime() - Date.now() <= seconds * 1000;
+    }
+
+}
+
+interface IAccessTokenResponse {
+    access_token?: string;
+    token_type?: string;
+    expires_in?: number;
+    scope?: string;
+    error?: string;
+    error_description?: string;
+}

--- a/src/storage/IStorageLocation.ts
+++ b/src/storage/IStorageLocation.ts
@@ -1,0 +1,4 @@
+export interface IStorageLocation {
+    source: string;
+    id: string;
+}

--- a/src/storage/QueryStringHandler.ts
+++ b/src/storage/QueryStringHandler.ts
@@ -1,0 +1,83 @@
+import type { IStorageLocation } from "./IStorageLocation";
+
+export class QueryStringHandler {
+    private readonly initialPath: string;
+    private readonly initialQueryString: string;
+    private readonly params: Map<string, string> = new Map();
+
+    constructor() {
+        const url = new URL(window.location.href);
+        this.initialPath = url.pathname;
+        this.initialQueryString = url.search;
+        this.params = QueryStringHandler.parseQueryString(this.initialQueryString);
+    }
+
+    public getStorageLocation(): IStorageLocation | null {
+        const source = this.params.get('s');
+        if (!source) return null;
+
+        const locationId = this.params.get('l');
+        if (!locationId) return null;
+
+        return { source, id: locationId };
+    }
+
+    public setStorageLocation(location: IStorageLocation): void {
+        this.params.set('s', location.source);
+        this.params.set('l', location.id);
+
+        const newQueryString = QueryStringHandler.stringifyQueryString(this.params);
+        const newUrl = this.initialPath + newQueryString;
+
+        window.history.replaceState({}, '', newUrl);
+    }
+
+    /**
+     * Parses a query string into a Map of key/value pairs.
+     * @param queryString - The query string (e.g., "?name=John&age=30")
+     * @returns A Map where each key/value pair is a parameter from the query string.
+     */
+    public static parseQueryString(queryString: string): Map<string, string> {
+        const params = new Map<string, string>();
+
+        // Remove the leading '?' if it's there.
+        if (queryString.startsWith('?')) {
+            queryString = queryString.substring(1);
+        }
+
+        // Split the string by '&' to get each key-value pair.
+        queryString.split('&').forEach(pair => {
+            if (!pair) return; // Skip any empty strings.
+
+            // Split the pair by '='. Default value is empty string if undefined.
+            const [rawKey, rawValue = ''] = pair.split('=');
+
+            // Decode URI components to handle encoded characters.
+            const key = decodeURIComponent(rawKey);
+            const value = decodeURIComponent(rawValue);
+
+            params.set(key, value);
+        });
+
+        return params;
+    }
+
+    /**
+     * Converts a Map of key/value pairs into a query string.
+     * @param params - A Map containing query parameters.
+     * @returns A query string starting with '?' if there are any parameters, or an empty string.
+     */
+    public static stringifyQueryString(params: Map<string, string>): string {
+        const queryArray: string[] = [];
+
+        // Iterate over the Map and encode each key/value pair.
+        params.forEach((value, key) => {
+            const encodedKey = encodeURIComponent(key);
+            const encodedValue = encodeURIComponent(value);
+            queryArray.push(`${encodedKey}=${encodedValue}`);
+        });
+
+        // Join pairs with '&' and prepend '?' if there are any parameters.
+        return queryArray.length ? '?' + queryArray.join('&') : '';
+    }
+}


### PR DESCRIPTION
## Summary
- integrate Google Drive storage service
- load Google API and identity scripts
- auto sign-in and choose/create a Drive file if none specified in the URL
- autosave tasks to Drive and show spinner while saving
- document Google Drive workflow
- fix build errors

## Testing
- `npm test`
- `npm run build`
- `../publish`


------
https://chatgpt.com/codex/tasks/task_e_6856c6c5314883319748e27d7cd585f5