### PR TITLE
Adjust pie chart interactions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -92,8 +92,7 @@
 }
 
 .pie path.selected {
-  stroke: yellow;
-  stroke-width: 3;
+  filter: brightness(1.4);
 }
 
 @media (max-width: 600px) {

--- a/src/storage/GoogleDriveService.ts
+++ b/src/storage/GoogleDriveService.ts
@@ -79,12 +79,13 @@ export class GoogleDriveService {
     public async signIn(): Promise<boolean> {
         await this.init()
         return new Promise((resolve, reject) => {
-            if (!this.tokenClient) {
+            const tokenClient = this.tokenClient;
+            if (!tokenClient) {
                 return reject(new Error('Token client not initialized.'))
             }
             // Temporarily override the callback for this sign-in attempt.
-            const originalCallback = this.tokenClient.callback;
-            this.tokenClient.callback = (response: IAccessTokenResponse) => {
+            const originalCallback = tokenClient.callback;
+            tokenClient.callback = (response: IAccessTokenResponse) => {
                 if (response.error) {
                     console.error("Sign-in error:", response.error);
                     resolve(false);
@@ -95,9 +96,9 @@ export class GoogleDriveService {
                     resolve(true);
                 }
                 // Restore the original callback.
-                this.tokenClient.callback = originalCallback;
+                tokenClient.callback = originalCallback;
             };
-            this.tokenClient.requestAccessToken();
+            tokenClient.requestAccessToken();
         });
     }
 

--- a/src/utils/pie.test.ts
+++ b/src/utils/pie.test.ts
@@ -3,6 +3,8 @@ import {
   polarToCartesian,
   calculateAngles,
   calculateRotation,
+  scaleAngles,
+  interpolateAngles,
   describeRingArc,
 } from './pie'
 
@@ -36,12 +38,12 @@ describe('calculateAngles', () => {
 
 describe('calculateRotation', () => {
   it('rotates for desktop', () => {
-    const rot = calculateRotation(Math.PI / 4, false)
+    const rot = calculateRotation(Math.PI / 4)
     expect(rot).toBeCloseTo(-Math.PI / 4)
   })
   it('rotates for mobile', () => {
-    const rot = calculateRotation(Math.PI / 4, true)
-    expect(rot).toBeCloseTo(-Math.PI / 2 - Math.PI / 4)
+    const rot = calculateRotation(Math.PI / 4)
+    expect(rot).toBeCloseTo(-Math.PI / 4)
   })
 })
 
@@ -50,5 +52,39 @@ describe('describeRingArc', () => {
     const path = describeRingArc(0, 0, 1, 2, 0, Math.PI)
     expect(path.startsWith('M')).toBe(true)
     expect(path.endsWith('Z')).toBe(true)
+  })
+})
+
+describe('scaleAngles', () => {
+  it('maps angles to a new range', () => {
+    const original = calculateAngles([
+      { effort: 1 },
+      { effort: 1 },
+    ])
+    const start = Math.PI / 2
+    const end = Math.PI
+    const scaled = scaleAngles(original, start, end)
+    expect(scaled[0].start).toBeCloseTo(start)
+    expect(scaled[0].end).toBeCloseTo(start + (end - start) / 2)
+    expect(scaled[1].start).toBeCloseTo(start + (end - start) / 2)
+    expect(scaled[1].end).toBeCloseTo(end)
+  })
+})
+
+describe('interpolateAngles', () => {
+  it('blends between angle sets', () => {
+    const from = [
+      { start: 0, end: Math.PI / 2, mid: Math.PI / 4 },
+      { start: Math.PI / 2, end: Math.PI, mid: (3 * Math.PI) / 4 },
+    ]
+    const to = [
+      { start: 0, end: Math.PI, mid: Math.PI / 2 },
+      { start: Math.PI, end: Math.PI * 2, mid: (3 * Math.PI) / 2 },
+    ]
+    const blended = interpolateAngles(from, to, 0.5)
+    expect(blended[0].start).toBeCloseTo(0)
+    expect(blended[0].end).toBeCloseTo((Math.PI / 2 + Math.PI) / 2)
+    expect(blended[1].start).toBeCloseTo((Math.PI / 2 + Math.PI) / 2)
+    expect(blended[1].end).toBeCloseTo((Math.PI + Math.PI * 2) / 2)
   })
 })

--- a/src/utils/pie.ts
+++ b/src/utils/pie.ts
@@ -72,7 +72,36 @@ export function calculateAngles<T extends TaskLike>(tasks: T[]): AngleInfo[] {
   })
 }
 
-export function calculateRotation(midAngle: number, isMobile: boolean): number {
-  const target = isMobile ? -Math.PI / 2 : 0
-  return target - midAngle
+export function calculateRotation(midAngle: number): number {
+  // Rotate so the selected slice points to the right on all devices
+  return -midAngle
+}
+
+export function scaleAngles(
+  angles: AngleInfo[],
+  start: number,
+  end: number,
+): AngleInfo[] {
+  const span = end - start
+  const full = Math.PI * 2
+  return angles.map((a) => ({
+    start: start + (a.start / full) * span,
+    end: start + (a.end / full) * span,
+    mid: start + (a.mid / full) * span,
+  }))
+}
+
+export function interpolateAngles(
+  from: AngleInfo[],
+  to: AngleInfo[],
+  t: number,
+): AngleInfo[] {
+  return from.map((f, i) => {
+    const target = to[i]
+    return {
+      start: f.start + (target.start - f.start) * t,
+      end: f.end + (target.end - f.end) * t,
+      mid: f.mid + (target.mid - f.mid) * t,
+    }
+  })
 }


### PR DESCRIPTION
## Summary
- update pie coloring and highlight style
- align rotation logic across mobile/desktop
- map child angles to their parent sector
- update tests
- fix Drive service Promise narrowing so build succeeds
- add tests for scaleAngles helper
- animate child angles during transition

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685bef6738d08331939ca73ebaa43978