### PR TITLE
Update pie chart and publish v0.0.16

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
-<!-- build version 0.0.15 -->
+<!-- build version 0.0.16 -->
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="build-version" content="0.0.15" />
+    <meta name="build-version" content="0.0.16" />
     <title>Vite + React + TS</title>
     <script src="https://apis.google.com/js/api.js"></script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>

--- a/src/App.css
+++ b/src/App.css
@@ -92,8 +92,8 @@
 }
 
 .pie path.selected {
-  stroke: yellow;
-  stroke-width: 3;
+  stroke: none;
+  filter: brightness(1.4);
 }
 
 @media (max-width: 600px) {

--- a/src/PieChart.tsx
+++ b/src/PieChart.tsx
@@ -27,8 +27,21 @@ export function PieChart({ tasks, path, onSelect, onUp }: Props) {
   const angles = calculateAngles(currentTasks)
   const selectedId = path[path.length - 1] ?? null
   const selectedTask = currentTasks.find((t) => t.id === selectedId) || null
+  const selectedIndex = currentTasks.findIndex((t) => t.id === selectedId)
   const childTasks = selectedTask ? selectedTask.subtasks : []
-  const childAngles = calculateAngles(childTasks)
+  const baseChildAngles = calculateAngles(childTasks)
+  const childAngles = selectedTask
+    ? baseChildAngles.map((a) => {
+        const parent = angles[selectedIndex]
+        const span = parent.end - parent.start
+        const scale = span / (Math.PI * 2)
+        return {
+          start: parent.start + a.start * scale,
+          end: parent.start + a.end * scale,
+          mid: parent.start + a.mid * scale,
+        }
+      })
+    : []
   const parentName = parentPath.length ? getTaskByPath(tasks, parentPath)?.name : ''
 
   return (
@@ -112,7 +125,7 @@ export function PieChart({ tasks, path, onSelect, onUp }: Props) {
           {childTasks.map((task, i) => {
             const { start, end, mid } = childAngles[i]
             const d = describeRingArc(0, 0, child.inner, child.outer, start, end)
-            const color = task.completed ? '#228b22' : '#777'
+            const color = task.completed ? '#006400' : '#555'
             const pos = polarToCartesian(0, 0, (child.inner + child.outer) / 2, mid)
             return (
               <g key={task.id} onClick={() => onSelect([...path, task.id])}>
@@ -135,7 +148,7 @@ export function PieChart({ tasks, path, onSelect, onUp }: Props) {
           {fadingChild.tasks.map((task, i) => {
             const { start, end } = fadingChild.angles[i]
             const d = describeRingArc(0, 0, fadingChild.radii.inner, fadingChild.radii.outer, start, end)
-            const color = task.completed ? '#228b22' : '#777'
+            const color = task.completed ? '#006400' : '#555'
             return <path key={task.id} d={d} fill={color} stroke="#000" />
           })}
         </g>

--- a/src/hooks/usePieAnimation.ts
+++ b/src/hooks/usePieAnimation.ts
@@ -1,4 +1,3 @@
-import { useIsMobile } from '../utils/useIsMobile'
 import {
   useAnimatedNumber,
   useAnimatedRadii,
@@ -42,7 +41,6 @@ export interface AnimatedLayers {
 }
 
 export function usePieAnimation(tasks: Task[], path: number[]): AnimatedLayers {
-  const isMobile = useIsMobile()
   const prevPath = usePrevious(path) || path
   const depthDiff = path.length - prevPath.length
   const transitionRef = useRef<
@@ -64,12 +62,23 @@ export function usePieAnimation(tasks: Task[], path: number[]): AnimatedLayers {
   const prevSelectedIndex = prevTasks.findIndex((t) => t.id === prevSelectedId)
   const prevRotationDeg =
     prevSelectedIndex >= 0
-      ? (calculateRotation(prevAngles[prevSelectedIndex].mid, isMobile) * 180) /
-        Math.PI
+      ? (calculateRotation(prevAngles[prevSelectedIndex].mid) * 180) / Math.PI
       : 0
   const prevSelectedTask = prevSelectedIndex >= 0 ? prevTasks[prevSelectedIndex] : null
   const prevChildTasks = prevSelectedTask ? prevSelectedTask.subtasks : []
-  const prevChildAngles = calculateAngles(prevChildTasks)
+  const prevBaseChildAngles = calculateAngles(prevChildTasks)
+  const prevChildAngles = prevSelectedTask
+    ? prevBaseChildAngles.map((a) => {
+        const parent = prevAngles[prevSelectedIndex]
+        const span = parent.end - parent.start
+        const scale = span / (Math.PI * 2)
+        return {
+          start: parent.start + a.start * scale,
+          end: parent.start + a.end * scale,
+          mid: parent.start + a.mid * scale,
+        }
+      })
+    : []
 
   if (!transitionRef.current && depthDiff !== 0) {
     transitionRef.current = {
@@ -90,7 +99,7 @@ export function usePieAnimation(tasks: Task[], path: number[]): AnimatedLayers {
   const angles = calculateAngles(currentTasks)
   const selectedIndex = currentTasks.findIndex((t) => t.id === selectedId)
   const targetRotation =
-    selectedIndex >= 0 ? calculateRotation(angles[selectedIndex].mid, isMobile) : 0
+    selectedIndex >= 0 ? calculateRotation(angles[selectedIndex].mid) : 0
 
   const rotationDeg =
     (useAnimatedNumber(targetRotation, 1500) * 180) / Math.PI

--- a/src/storage/GoogleDriveService.ts
+++ b/src/storage/GoogleDriveService.ts
@@ -95,9 +95,9 @@ export class GoogleDriveService {
                     resolve(true);
                 }
                 // Restore the original callback.
-                this.tokenClient.callback = originalCallback;
+                this.tokenClient!.callback = originalCallback;
             };
-            this.tokenClient.requestAccessToken();
+            this.tokenClient!.requestAccessToken();
         });
     }
 

--- a/src/utils/pie.test.ts
+++ b/src/utils/pie.test.ts
@@ -35,13 +35,9 @@ describe('calculateAngles', () => {
 })
 
 describe('calculateRotation', () => {
-  it('rotates for desktop', () => {
-    const rot = calculateRotation(Math.PI / 4, false)
+  it('rotates selected slice to the right', () => {
+    const rot = calculateRotation(Math.PI / 4)
     expect(rot).toBeCloseTo(-Math.PI / 4)
-  })
-  it('rotates for mobile', () => {
-    const rot = calculateRotation(Math.PI / 4, true)
-    expect(rot).toBeCloseTo(-Math.PI / 2 - Math.PI / 4)
   })
 })
 

--- a/src/utils/pie.ts
+++ b/src/utils/pie.ts
@@ -72,7 +72,7 @@ export function calculateAngles<T extends TaskLike>(tasks: T[]): AngleInfo[] {
   })
 }
 
-export function calculateRotation(midAngle: number, isMobile: boolean): number {
-  const target = isMobile ? -Math.PI / 2 : 0
-  return target - midAngle
+export function calculateRotation(midAngle: number): number {
+  // Always rotate the selected segment to the right side of the pie
+  return -midAngle
 }


### PR DESCRIPTION
## Summary
- update child ring sizing and colors in pie chart
- highlight slices with brightness instead of outline
- align selected slice on the right side for all devices
- adjust previous child angle handling and remove mobile rotation
- patch GoogleDriveService null assertions
- bump patch version to 0.0.16 and publish

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run publish`


------
https://chatgpt.com/codex/tasks/task_e_685d373ae2e883318348287b3011948a